### PR TITLE
Suppress numerical Steam IDs

### DIFF
--- a/SEDiscordBridge/DiscordBridge.cs
+++ b/SEDiscordBridge/DiscordBridge.cs
@@ -98,7 +98,10 @@ namespace SEDiscordBridge
             {
                 DiscordChannel chann = discord.GetChannelAsync(ulong.Parse(Plugin.Config.StatusChannelId)).Result;
                 
-                if (user != null)
+                //check to stop sending numerical steam IDs
+                bool isNumericalID = user.Contains("ID:");
+                
+                if (user != null && isNumericalID == false)
                 {
                     msg = msg.Replace("{p}", user);
                 }

--- a/SEDiscordBridge/DiscordBridge.cs
+++ b/SEDiscordBridge/DiscordBridge.cs
@@ -101,7 +101,7 @@ namespace SEDiscordBridge
                 //check to stop sending numerical steam IDs
                 bool isNumericalID = user.Contains("ID:");
                 
-                if (user != null && isNumericalID == false)
+                if (user != null && !isNumericalID)
                 {
                     msg = msg.Replace("{p}", user);
                 }


### PR DESCRIPTION
Use a simple string check to make sure numerical steam id's (i.e. "ID:12345678910 has left the server") do not appear in the server status chat.