### PR TITLE
Addition of the ability to add a simulation speed warning message and plugin reload command

### DIFF
--- a/SEDiscordBridge/Commands.cs
+++ b/SEDiscordBridge/Commands.cs
@@ -1,0 +1,30 @@
+using NLog;
+using Sandbox.Game.Entities;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Torch.Commands;
+using Torch.Commands.Permissions;
+using VRage.Game.ModAPI;
+using VRage.Groups;
+
+namespace SEDiscordBridge
+{
+
+    public class Commands : CommandModule
+    {
+
+        public static readonly Logger Log = LogManager.GetCurrentClassLogger();
+
+        public SEDiscordBridgePlugin Plugin => (SEDiscordBridgePlugin)Context.Plugin;
+
+        [Command("reload-bridge", "Reload current SEDB configuration")]
+        [Permission(MyPromoteLevel.Admin)]
+        public void ReloadBridge()
+        {
+            Plugin.LoadSEDB();
+            Context.Respond("Plugin reloaded!");
+
+        }
+    }
+}

--- a/SEDiscordBridge/DiscordBridge.cs
+++ b/SEDiscordBridge/DiscordBridge.cs
@@ -140,7 +140,7 @@ namespace SEDiscordBridge
                     if (user.StartsWith("ID:"))
                         return;
 
-                    msg = msg.Replace("{p}", user);
+                    msg = Plugin.Config.FacFormat.Replace("{msg}", msg).Replace("{p}", user).Replace("{ts}", TimeZone.CurrentTimeZone.ToLocalTime(DateTime.Now).ToString());
                 }
 
                 discord.SendMessageAsync(chann, msg.Replace("/n", "\n"));

--- a/SEDiscordBridge/DiscordBridge.cs
+++ b/SEDiscordBridge/DiscordBridge.cs
@@ -168,7 +168,7 @@ namespace SEDiscordBridge
                     if (user.StartsWith("ID:"))
                         return;
 
-                    msg = Plugin.Config.FacFormat.Replace("{msg}", msg).Replace("{p}", user).Replace("{ts}", TimeZone.CurrentTimeZone.ToLocalTime(DateTime.Now).ToString());
+                    msg = msg.Replace("{p}", user).Replace("{ts}", TimeZone.CurrentTimeZone.ToLocalTime(DateTime.Now).ToString());
                 }
 
                 discord.SendMessageAsync(chann, msg.Replace("/n", "\n"));

--- a/SEDiscordBridge/DiscordBridge.cs
+++ b/SEDiscordBridge/DiscordBridge.cs
@@ -28,7 +28,10 @@ namespace SEDiscordBridge
         public static int Cooldown;
         public static decimal Increment;
         public static decimal Factor;
-        
+        public static decimal CooldownNeutral;
+        public static int FirstWarning;
+        public static decimal MinIncrement;
+        public static decimal Locked;
         public DiscordBridge(SEDiscordBridgePlugin plugin)
         {
             Plugin = plugin;

--- a/SEDiscordBridge/DiscordBridge.cs
+++ b/SEDiscordBridge/DiscordBridge.cs
@@ -190,12 +190,6 @@ namespace SEDiscordBridge
 
                         if (Plugin.Torch.CurrentSession?.State == TorchSessionState.Loaded)
                         {
-                            if (cmdText == "reload-plugin" || cmdText == "Reload-Plugin")
-                            {
-                                Plugin.LoadSEDB();
-                                SendCmdResponse("Plugin reloaded!", e.Channel);
-                                return Task.CompletedTask;
-                            }
                             var manager = Plugin.Torch.CurrentSession.Managers.GetManager<CommandManager>();
                             var command = manager.Commands.GetCommand(cmdText, out string argText);
 

--- a/SEDiscordBridge/DiscordBridge.cs
+++ b/SEDiscordBridge/DiscordBridge.cs
@@ -82,6 +82,26 @@ namespace SEDiscordBridge
             }
         }
 
+        public void SendSimMessage(string msg)
+        {
+            try
+            {
+                if (Ready && Plugin.Config.SimChannel.Length > 0)
+                {
+                    DiscordChannel chann = discord.GetChannelAsync(ulong.Parse(Plugin.Config.SimChannel)).Result;
+                    //mention
+                    msg = MentionNameToID(msg, chann);
+                    msg = Plugin.Config.Format.Replace("{ts}", TimeZone.CurrentTimeZone.ToLocalTime(DateTime.Now).ToString());
+                    discord.SendMessageAsync(chann, msg.Replace("/n", "\n"));
+                }
+            }
+            catch (Exception e)
+            {
+                DiscordChannel chann = discord.GetChannelAsync(ulong.Parse(Plugin.Config.SimChannel)).Result;
+                discord.SendMessageAsync(chann, e.ToString());
+            }
+        }
+
         public void SendChatMessage(string user, string msg)
         {
             try

--- a/SEDiscordBridge/DiscordBridge.cs
+++ b/SEDiscordBridge/DiscordBridge.cs
@@ -190,6 +190,12 @@ namespace SEDiscordBridge
 
                         if (Plugin.Torch.CurrentSession?.State == TorchSessionState.Loaded)
                         {
+                            if (cmdText == "reload-plugin" || cmdText == "Reload-Plugin")
+                            {
+                                Plugin.LoadSEDB();
+                                SendCmdResponse("Plugin reloaded!", e.Channel);
+                                return Task.CompletedTask;
+                            }
                             var manager = Plugin.Torch.CurrentSession.Managers.GetManager<CommandManager>();
                             var command = manager.Commands.GetCommand(cmdText, out string argText);
 

--- a/SEDiscordBridge/DiscordBridge.cs
+++ b/SEDiscordBridge/DiscordBridge.cs
@@ -91,7 +91,7 @@ namespace SEDiscordBridge
                     DiscordChannel chann = discord.GetChannelAsync(ulong.Parse(Plugin.Config.SimChannel)).Result;
                     //mention
                     msg = MentionNameToID(msg, chann);
-                    msg = Plugin.Config.Format.Replace("{ts}", TimeZone.CurrentTimeZone.ToLocalTime(DateTime.Now).ToString());
+                    msg = Plugin.Config.SimMessage.Replace("{ts}", TimeZone.CurrentTimeZone.ToLocalTime(DateTime.Now).ToString());
                     discord.SendMessageAsync(chann, msg.Replace("/n", "\n"));
                 }
             }

--- a/SEDiscordBridge/DiscordBridge.cs
+++ b/SEDiscordBridge/DiscordBridge.cs
@@ -25,10 +25,15 @@ namespace SEDiscordBridge
         private string lastMessage = "";
 
         public bool Ready { get; set; } = false;
-
+        public static int Cooldown;
+        public static decimal Increment;
+        public static decimal Factor;
+        
         public DiscordBridge(SEDiscordBridgePlugin plugin)
         {
             Plugin = plugin;
+            int Cooldown = Plugin.Config.SimCooldown;
+            decimal Increment = Cooldown / Plugin.Config.StatusInterval;
 
             thread = new Thread(() =>
             {

--- a/SEDiscordBridge/DiscordBridge.cs
+++ b/SEDiscordBridge/DiscordBridge.cs
@@ -13,6 +13,7 @@ using Torch.API.Session;
 using Torch.Commands;
 using VRage.Game;
 using VRage.Game.ModAPI;
+using Torch.Server;
 
 namespace SEDiscordBridge
 {

--- a/SEDiscordBridge/DiscordBridge.cs
+++ b/SEDiscordBridge/DiscordBridge.cs
@@ -91,7 +91,7 @@ namespace SEDiscordBridge
                     DiscordChannel chann = discord.GetChannelAsync(ulong.Parse(Plugin.Config.SimChannel)).Result;
                     //mention
                     msg = MentionNameToID(msg, chann);
-                    msg = Plugin.Config.SimMessage.Replace("{ts}", TimeZone.CurrentTimeZone.ToLocalTime(DateTime.Now).ToString());
+                    msg = Plugin.Config.Format.Replace("{ts}", TimeZone.CurrentTimeZone.ToLocalTime(DateTime.Now).ToString());
                     discord.SendMessageAsync(chann, msg.Replace("/n", "\n"));
                 }
             }

--- a/SEDiscordBridge/SEDBConfig.cs
+++ b/SEDiscordBridge/SEDBConfig.cs
@@ -74,6 +74,9 @@ namespace SEDiscordBridge
         private string _simMessage = "@here Simulation speed has dropped below threshold!";
         public string SimMessage { get => _simMessage; set => SetValue(ref _simMessage, value); }
 
+        private string _simCooldown = "1200";
+        public string SimCooldown { get => _simCooldown; set => SetValue(ref _simCooldown, value); }
+
         private bool _useStatus = true;
         public bool UseStatus { get => _useStatus; set => SetValue(ref _useStatus, value); }
 

--- a/SEDiscordBridge/SEDBConfig.cs
+++ b/SEDiscordBridge/SEDBConfig.cs
@@ -74,8 +74,8 @@ namespace SEDiscordBridge
         private string _simMessage = "@here Simulation speed has dropped below threshold!";
         public string SimMessage { get => _simMessage; set => SetValue(ref _simMessage, value); }
 
-        private string _simCooldown = "1200";
-        public string SimCooldown { get => _simCooldown; set => SetValue(ref _simCooldown, value); }
+        private int _simCooldown = 1200;
+        public int SimCooldown { get => _simCooldown; set => SetValue(ref _simCooldown, value); }
 
         private bool _useStatus = true;
         public bool UseStatus { get => _useStatus; set => SetValue(ref _useStatus, value); }

--- a/SEDiscordBridge/SEDBConfig.cs
+++ b/SEDiscordBridge/SEDBConfig.cs
@@ -62,6 +62,18 @@ namespace SEDiscordBridge
         private string _leave = ":new_moon: The player {p} left the server";
         public string Leave { get => _leave; set => SetValue(ref _leave, value); }
 
+        private bool _simPing = false;
+        public bool SimPing { get => _simPing; set => SetValue(ref _simPing, value); }
+
+        private string _simChannel = "";
+        public string SimChannel { get => _simChannel; set => SetValue(ref _simChannel, value); }
+
+        private string _simThresh = "0.60";
+        public string SimThresh { get => _simThresh; set => SetValue(ref _simThresh, value); }
+
+        private string _simMessage = "@here Simulation speed has dropped below threshold!";
+        public string SimMessage { get => _simMessage; set => SetValue(ref _simMessage, value); }
+
         private bool _useStatus = true;
         public bool UseStatus { get => _useStatus; set => SetValue(ref _useStatus, value); }
 

--- a/SEDiscordBridge/SEDBControl.xaml
+++ b/SEDiscordBridge/SEDBControl.xaml
@@ -125,6 +125,10 @@
             <TextBox Width="180" Text="{Binding SimMessage}" Margin="3" ToolTip="Format: 1.00"/>
             <Label Content="Threshold Met Message" />
         </StackPanel>
+        <StackPanel Orientation="Horizontal">
+            <TextBox Width="60" Text="{Binding SimCooldown}" Margin="3" ToolTip="5 = Five seconds "/>
+            <Label Content="Cooldown after notifacation trigger (seconds)" />
+        </StackPanel>
 
         <Label Height="20">
             <LineBreak/>

--- a/SEDiscordBridge/SEDBControl.xaml
+++ b/SEDiscordBridge/SEDBControl.xaml
@@ -21,8 +21,8 @@
         <CheckBox Content="Enabled" Margin="3" IsChecked="{Binding Enabled}" ToolTip="Enable or disable SEDiscordBridge"/>
         <CheckBox Content="Load Bot before server start" Margin="3" IsChecked="{Binding PreLoad}" ToolTip="Load BOT before server start? Good to test or check if boot is connecting!"/>
         <CheckBox Content="Send simulation speed to captainjackyt.com for analytics" Margin="3" IsChecked="{Binding DataCollect}" ToolTip="Enabling this will send simulation speed and player count to stated website"/>
-        
-        
+
+
 
         <Label Width="Auto">
             <Hyperlink NavigateUri="https://goo.gl/5Do8LJ" RequestNavigate="Hyperlink_RequestNavigate">
@@ -84,6 +84,7 @@
         </Label>
 
         <Label FontWeight="Bold" FontSize="16" Content="Status Messages:" />
+
         <StackPanel Orientation="Horizontal">
             <TextBox Width="180" Text="{Binding StatusChannelId}" ToolTip="Discord channel to send status messages" Margin="3" />
             <Label Content="Channel id for status messages"/>
@@ -107,6 +108,18 @@
         <StackPanel Orientation="Horizontal">
             <TextBox Width="180" Text="{Binding Leave}" Margin="3" ToolTip="Use {p} for player name. Leave empty to disable"/>
             <Label Content="Player Leave Message" />
+        </StackPanel>
+        <Label Height="20">
+            <LineBreak/>
+        </Label>
+        <CheckBox Content="Send message when server drops below a set sim speed" Margin="3" IsChecked="{Binding SimPing}" ToolTip="Send message when simulation speed averages below a set threshold"/>
+        <StackPanel Orientation="Horizontal">
+            <TextBox Width="60" Text="{Binding SimThresh}" Margin="3" ToolTip="Format: 1.00"/>
+            <Label Content="Average Sim Threshold" />
+        </StackPanel>
+        <StackPanel Orientation="Horizontal">
+            <TextBox Width="180" Text="{Binding SimMessage}" Margin="3" ToolTip="Format: 1.00"/>
+            <Label Content="Threshold Met Message" />
         </StackPanel>
 
         <Label Height="20">
@@ -177,12 +190,6 @@
                 </DataGrid.Columns>
             </DataGrid>
         </StackPanel>
-        <Label Height="20">
-            <LineBreak/>
-        </Label>
-        
-
-
         <Label Height="20">
             <LineBreak/>
         </Label>

--- a/SEDiscordBridge/SEDBControl.xaml
+++ b/SEDiscordBridge/SEDBControl.xaml
@@ -114,6 +114,10 @@
         </Label>
         <CheckBox Content="Send message when server drops below a set sim speed" Margin="3" IsChecked="{Binding SimPing}" ToolTip="Send message when simulation speed averages below a set threshold"/>
         <StackPanel Orientation="Horizontal">
+            <TextBox Width="180" Text="{Binding SimChannel}" ToolTip="Discord channel to send simulation messages" Margin="3" />
+            <Label Content="Channel id for simulation messages"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal">
             <TextBox Width="60" Text="{Binding SimThresh}" Margin="3" ToolTip="Format: 1.00"/>
             <Label Content="Average Sim Threshold" />
         </StackPanel>

--- a/SEDiscordBridge/SEDBControl.xaml
+++ b/SEDiscordBridge/SEDBControl.xaml
@@ -109,9 +109,7 @@
             <TextBox Width="180" Text="{Binding Leave}" Margin="3" ToolTip="Use {p} for player name. Leave empty to disable"/>
             <Label Content="Player Leave Message" />
         </StackPanel>
-        <Label Height="20">
-            <LineBreak/>
-        </Label>
+        <Label FontWeight="Bold" FontSize="16" Content="Sim Status Messages:" />
         <CheckBox Content="Send message when server drops below a set sim speed" Margin="3" IsChecked="{Binding SimPing}" ToolTip="Send message when simulation speed averages below a set threshold"/>
         <StackPanel Orientation="Horizontal">
             <TextBox Width="180" Text="{Binding SimChannel}" ToolTip="Discord channel to send simulation messages" Margin="3" />

--- a/SEDiscordBridge/SEDBControl.xaml
+++ b/SEDiscordBridge/SEDBControl.xaml
@@ -116,7 +116,7 @@
             <Label Content="Channel id for simulation messages"/>
         </StackPanel>
         <StackPanel Orientation="Horizontal">
-            <TextBox Width="60" Text="{Binding SimThresh}" Margin="3" ToolTip="Format: 1.00"/>
+            <TextBox Width="180" Text="{Binding SimThresh}" Margin="3" ToolTip="Format: 1.00"/>
             <Label Content="Average Sim Threshold" />
         </StackPanel>
         <StackPanel Orientation="Horizontal">
@@ -124,7 +124,7 @@
             <Label Content="Threshold Met Message" />
         </StackPanel>
         <StackPanel Orientation="Horizontal">
-            <TextBox Width="60" Text="{Binding SimCooldown}" Margin="3" ToolTip="5 = Five seconds "/>
+            <TextBox Width="180" Text="{Binding SimCooldown}" Margin="3" ToolTip="5 = Five seconds "/>
             <Label Content="Cooldown after notifacation trigger (seconds)" />
         </StackPanel>
 

--- a/SEDiscordBridge/SEDiscordBridge.csproj
+++ b/SEDiscordBridge/SEDiscordBridge.csproj
@@ -155,6 +155,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Commands.cs" />
     <Compile Include="SEDBCommandHandler.cs" />
     <Compile Include="DiscordBridge.cs" />
     <Compile Include="SEDiscordBridgePlugin.cs" />

--- a/SEDiscordBridge/SEDiscordBridgePlugin.cs
+++ b/SEDiscordBridge/SEDiscordBridgePlugin.cs
@@ -215,6 +215,12 @@ namespace SEDiscordBridge
             Log.Info("Starting Discord Bridge!");
             if (DDBridge == null)
                 DDBridge = new DiscordBridge(this);
+            DiscordBridge.Cooldown = Config.SimCooldown;
+            DiscordBridge.Increment = (Config.StatusInterval / 1000);
+            DiscordBridge.Factor = Config.SimCooldown / DiscordBridge.Increment;
+            DiscordBridge.Increment = Config.SimCooldown / DiscordBridge.Increment;
+            DiscordBridge.MinIncrement = 60 / (Config.StatusInterval / 1000);
+            DiscordBridge.Locked = 0;
 
             //send status
             if (Config.UseStatus)
@@ -281,9 +287,7 @@ namespace SEDiscordBridge
                 {
                     if (torchServer.SimulationRatio < float.Parse(Config.SimThresh))
                     {
-                        Log.Warn(i + " " + DiscordBridge.CooldownNeutral.ToString("00.00"));
                         //condition
-                        // DiscordBridge.CooldownNeutral == Config.SimCooldown
                         if (i == DiscordBridge.MinIncrement && DiscordBridge.Locked != 1)
                         {
                             Task.Run(() => DDBridge.SendSimMessage(Config.SimMessage));
@@ -311,9 +315,6 @@ namespace SEDiscordBridge
                         DiscordBridge.CooldownNeutral = 0;
                     }
                 }
-
-
-
                 if (Config.DataCollect)
                 {
                     try

--- a/SEDiscordBridge/SEDiscordBridgePlugin.cs
+++ b/SEDiscordBridge/SEDiscordBridgePlugin.cs
@@ -234,11 +234,31 @@ namespace SEDiscordBridge
                 _timer = null;
             }
         }
-
+        // for counter within _timer_elapsed() 
+        private int i = 0;
         private DateTime timerStart = new DateTime(0);
         private void _timer_Elapsed(object sender, ElapsedEventArgs e)
         {
             if (!Config.Enabled || DDBridge == null) return;
+
+            if (Config.SimPing)
+            {
+                if (torchServer.SimulationRatio < float.Parse(Config.SimThresh))
+                {
+                    i++;
+                    //i == 12 represents a minuete passing
+                    if (i == 12)
+                    {
+                        Task.Run(() => DDBridge.SendSimMessage(Config.SimMessage));
+                    }
+                }
+                else
+                {
+                    //reset counter whenever Sim speed warning threshold is not met meaning that sim speed has to stay below
+                    //the set threshold for a consecutive minuete to trigger warning
+                    i = 0;
+                }
+            }
 
             if (Torch.CurrentSession == null)
             {

--- a/SEDiscordBridge/SEDiscordBridgePlugin.cs
+++ b/SEDiscordBridge/SEDiscordBridgePlugin.cs
@@ -295,11 +295,12 @@ namespace SEDiscordBridge
                             DiscordBridge.Locked = 1;
                             DiscordBridge.FirstWarning = 1;
                             DiscordBridge.CooldownNeutral = 0;
-                            Log.Fatal("RUN");
+                            Log.Warn("Simulation warning sent!");
                         }
                         if (DiscordBridge.FirstWarning == 1 && DiscordBridge.CooldownNeutral.ToString("00") == "60")
                         {
                             Task.Run(() => DDBridge.SendSimMessage(Config.SimMessage));
+                            Log.Warn("Simulation warning sent!");
                             DiscordBridge.CooldownNeutral = 0;
                             i = 0;
 

--- a/SEDiscordBridge/SEDiscordBridgePlugin.cs
+++ b/SEDiscordBridge/SEDiscordBridgePlugin.cs
@@ -152,6 +152,7 @@ namespace SEDiscordBridge
             Dispose();
         }
 
+
         public void LoadSEDB()
         {
             if (Config.BotToken.Length <= 0)

--- a/SEDiscordBridge/SEDiscordBridgePlugin.cs
+++ b/SEDiscordBridge/SEDiscordBridgePlugin.cs
@@ -241,31 +241,31 @@ namespace SEDiscordBridge
         {
             if (!Config.Enabled || DDBridge == null) return;
 
-            if (Config.SimPing)
-            {
-                if (torchServer.SimulationRatio < float.Parse(Config.SimThresh))
-                {
-                    i++;
-                    //i == 12 represents a minuete passing
-                    if (i == 12)
-                    {
-                        Task.Run(() => DDBridge.SendSimMessage(Config.SimMessage));
-                    }
-                }
-                else
-                {
-                    //reset counter whenever Sim speed warning threshold is not met meaning that sim speed has to stay below
-                    //the set threshold for a consecutive minuete to trigger warning
-                    i = 0;
-                }
-            }
-
             if (Torch.CurrentSession == null)
             {
                 DDBridge.SendStatus(Config.StatusPre);
             }
             else
             {
+                if (Config.SimPing)
+                {
+                    if (torchServer.SimulationRatio < float.Parse(Config.SimThresh))
+                    {
+                        i++;
+                        //i == 12 represents a minuete passing
+                        if (i == 12)
+                        {
+                            Task.Run(() => DDBridge.SendSimMessage(Config.SimMessage));
+                            i = 0;
+                        }
+                    }
+                    else
+                    {
+                        //reset counter whenever Sim speed warning threshold is not met meaning that sim speed has to stay below
+                        //the set threshold for a consecutive minuete to trigger warning
+                        i = 0;
+                    }
+                }
                 if (timerStart.Ticks == 0) timerStart = e.SignalTime;
 
                 string status = Config.Status;

--- a/SEDiscordBridge/SEDiscordBridgePlugin.cs
+++ b/SEDiscordBridge/SEDiscordBridgePlugin.cs
@@ -284,17 +284,20 @@ namespace SEDiscordBridge
                         Log.Warn(i + " " + DiscordBridge.CooldownNeutral.ToString("00.00"));
                         //condition
                         // DiscordBridge.CooldownNeutral == Config.SimCooldown
-                        if (i == DiscordBridge.MinIncrement||DiscordBridge.FirstWarning == 0 && DiscordBridge.Locked != 1)
+                        if (i == DiscordBridge.MinIncrement && DiscordBridge.Locked != 1)
                         {
                             Task.Run(() => DDBridge.SendSimMessage(Config.SimMessage));
                             i = 0;
                             DiscordBridge.Locked = 1;
                             DiscordBridge.FirstWarning = 1;
+                            DiscordBridge.CooldownNeutral = 0;
+                            Log.Fatal("RUN");
                         }
-                        if (DiscordBridge.FirstWarning == 0 || DiscordBridge.CooldownNeutral == Config.SimCooldown)
+                        if (DiscordBridge.FirstWarning == 1 && DiscordBridge.CooldownNeutral.ToString("00") == "60")
                         {
                             Task.Run(() => DDBridge.SendSimMessage(Config.SimMessage));
                             DiscordBridge.CooldownNeutral = 0;
+                            i = 0;
 
                         } 
                         DiscordBridge.CooldownNeutral += (60/DiscordBridge.Factor);

--- a/SEDiscordBridge/SEDiscordBridgePlugin.cs
+++ b/SEDiscordBridge/SEDiscordBridgePlugin.cs
@@ -240,23 +240,27 @@ namespace SEDiscordBridge
         private void _timer_Elapsed(object sender, ElapsedEventArgs e)
         {
             if (!Config.Enabled || DDBridge == null) return;
-
-            if (Config.SimPing)
+            if (Torch.CurrentSession != null)
             {
-                if (torchServer.SimulationRatio < float.Parse(Config.SimThresh))
+                if (Config.SimPing)
                 {
-                    i++;
-                    //i == 12 represents a minuete passing
-                    if (i == 12)
+                    if (torchServer.SimulationRatio < float.Parse(Config.SimThresh))
                     {
-                        Task.Run(() => DDBridge.SendSimMessage(Config.SimMessage));
+                        i++;
+                        //i == 12 represents a minuete passing
+                        if (i == 12)
+                        {
+                            Task.Run(() => DDBridge.SendSimMessage(Config.SimMessage));
+                            i = 0;
+                            Log.Fatal("RUN");
+                        }
                     }
-                }
-                else
-                {
-                    //reset counter whenever Sim speed warning threshold is not met meaning that sim speed has to stay below
-                    //the set threshold for a consecutive minuete to trigger warning
-                    i = 0;
+                    else
+                    {
+                        //reset counter whenever Sim speed warning threshold is not met meaning that sim speed has to stay below
+                        //the set threshold for a consecutive minuete to trigger warning
+                        i = 0;
+                    }
                 }
             }
 

--- a/SEDiscordBridge/SEDiscordBridgePlugin.cs
+++ b/SEDiscordBridge/SEDiscordBridgePlugin.cs
@@ -240,27 +240,23 @@ namespace SEDiscordBridge
         private void _timer_Elapsed(object sender, ElapsedEventArgs e)
         {
             if (!Config.Enabled || DDBridge == null) return;
-            if (Torch.CurrentSession != null)
+
+            if (Config.SimPing)
             {
-                if (Config.SimPing)
+                if (torchServer.SimulationRatio < float.Parse(Config.SimThresh))
                 {
-                    if (torchServer.SimulationRatio < float.Parse(Config.SimThresh))
+                    i++;
+                    //i == 12 represents a minuete passing
+                    if (i == 12)
                     {
-                        i++;
-                        //i == 12 represents a minuete passing
-                        if (i == 12)
-                        {
-                            Task.Run(() => DDBridge.SendSimMessage(Config.SimMessage));
-                            i = 0;
-                            Log.Fatal("RUN");
-                        }
+                        Task.Run(() => DDBridge.SendSimMessage(Config.SimMessage));
                     }
-                    else
-                    {
-                        //reset counter whenever Sim speed warning threshold is not met meaning that sim speed has to stay below
-                        //the set threshold for a consecutive minuete to trigger warning
-                        i = 0;
-                    }
+                }
+                else
+                {
+                    //reset counter whenever Sim speed warning threshold is not met meaning that sim speed has to stay below
+                    //the set threshold for a consecutive minuete to trigger warning
+                    i = 0;
                 }
             }
 


### PR DESCRIPTION
This adds a new set of controls for enabling/disabling the ability to send a customised alert to a set discord channel and also has a optional cool down feature in order to prevent bot spamming.

Also additional command added (!reload-bridge) which reloads the plugin and cfg with no need to restart